### PR TITLE
optional chaining to prevent error during ng add

### DIFF
--- a/libs/ddd/src/schematics/utils/update-linting-rules.ts
+++ b/libs/ddd/src/schematics/utils/update-linting-rules.ts
@@ -32,7 +32,7 @@ export function checkRuleExists(rules: object, context: SchematicContext) {
 
 export function addDomainToLintingRules(domainName: string): Rule {
   return (host: Tree, context: SchematicContext) => {
-    const text = host.read('tslint.json').toString();
+    const text = host.read('tslint.json')?.toString();
     const rules = JSON.parse(text);
 
     if (!checkRuleExists(rules, context)) return;


### PR DESCRIPTION
If there is no tslint.json an error occurs. With optional chaining we can catch that. 

Closes Issue #2